### PR TITLE
some typos

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -69,7 +69,7 @@ passport.use(new BearerStrategy(
       if (error) return done(error);
       if (!token) return done(null, false);
       if (token.userId) {
-        db.users.findByUserId(token.userId, (error, user) => {
+        db.users.findById(token.userId, (error, user) => {
           if (error) return done(error);
           if (!user) return done(null, false);
           // To keep this example simple, restricted scopes are not implemented,

--- a/routes/oauth2.js
+++ b/routes/oauth2.js
@@ -176,7 +176,7 @@ module.exports.authorization = [
     });
   }),
   (request, response) => {
-    response.render('dialog', { transactionId: request.oauth2.transactionId, user: request.user, client: request.oauth2.client });
+    response.render('dialog', { transactionId: request.oauth2.transactionID, user: request.user, client: request.oauth2.client });
   },
 ];
 


### PR DESCRIPTION
db.users.findByUserId is undefined, must be a typo. Corrected to findById.

transactionID in request.oauth2 is with a capital D, not small.